### PR TITLE
Fix the typo of attribute name decision_score_

### DIFF
--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -19,7 +19,7 @@ def main(args):
             score = model.decision_function(data.x)
         else:
             model.fit(data)
-            score = model.decision_scores_
+            score = model.decision_score_
 
         y = data.y.bool()
         k = sum(y)

--- a/benchmark/time.py
+++ b/benchmark/time.py
@@ -28,7 +28,7 @@ def main(args):
         else:
             model.fit(data)
             t = time.time() - start_time
-            score = model.decision_scores_
+            score = model.decision_score_
 
         if os.path.isdir('./tmp'):
             shutil.rmtree('./tmp')

--- a/benchmark/type.py
+++ b/benchmark/type.py
@@ -21,7 +21,7 @@ def main(args):
             score = model.decision_function(data.x)
         else:
             model.fit(data)
-            score = model.decision_scores_
+            score = model.decision_score_
 
         yc = data.y >> 0 & 1
         ys = data.y >> 1 & 1

--- a/docs/tigergraph_pygod_demo.ipynb
+++ b/docs/tigergraph_pygod_demo.ipynb
@@ -1,13 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# PyGOD Demo on TigerGraph ML Workbench\n",
     "This notebook demonstrates how to run Python Graph Outlier Detection (PyGOD) package on TigerGraph Database and TigerGraph ML workbench. Please install the TigerGraph server (https://docs.tigergraph.com/tigergraph-server/current/intro/) on your local machine or remote server first, read the data ingestion tutorial from Tigergraph (https://github.com/TigerGraph-DevLabs/mlworkbench-docs/tree/main/tutorials/basics) and download necessary data files.\n",
     "We use the Cora data for demo."
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -24,11 +24,11 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Data Ingestion\n"
-   ],
-   "cell_type": "markdown",
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
@@ -414,7 +414,7 @@
     }
    ],
    "source": [
-    "outlier_scores = model.decision_scores_ # raw outlier scores on the input data\n",
+    "outlier_scores = model.decision_score_ # raw outlier scores on the input data\n",
     "print(outlier_scores)"
    ]
   },


### PR DESCRIPTION
The argument should be `decision_score_` other than `decision_scores_` in a model object according to the [definition of class `Detector`](https://github.com/pygod-team/pygod/blob/main/pygod/detector/base.py#L37)