### PR TITLE
fix torch.mean(auc) and updating model init in utils.py

### DIFF
--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -28,9 +28,20 @@ def main(args):
             warnings.warn('contains NaN, skip one trial.')
             continue
 
-        auc.append(eval_roc_auc(y, score))
-        ap.append(eval_average_precision(y, score))
-        rec.append(eval_recall_at_k(y, score, k))
+        auc_val = eval_roc_auc(y, score)
+        auc.append(auc_val)
+
+        ap_val = eval_average_precision(y, score)
+        ap.append(ap_val)
+
+        rec_val = eval_recall_at_k(y, score, k)
+        if isinstance(rec_val, torch.Tensor):
+            rec_val = rec_val.tolist()
+        rec.append(rec_val)
+
+    auc = torch.tensor(auc)
+    ap = torch.tensor(ap)
+    rec = torch.tensor(rec)
 
     print(args.dataset + " " + model.__class__.__name__ + " " +
           "AUC: {:.4f}±{:.4f} ({:.4f})\t"

--- a/benchmark/main.py
+++ b/benchmark/main.py
@@ -28,16 +28,9 @@ def main(args):
             warnings.warn('contains NaN, skip one trial.')
             continue
 
-        auc_val = eval_roc_auc(y, score)
-        auc.append(auc_val)
-
-        ap_val = eval_average_precision(y, score)
-        ap.append(ap_val)
-
-        rec_val = eval_recall_at_k(y, score, k)
-        if isinstance(rec_val, torch.Tensor):
-            rec_val = rec_val.tolist()
-        rec.append(rec_val)
+        auc.append(eval_roc_auc(y, score))
+        ap.append(eval_average_precision(y, score))
+        rec.append(eval_recall_at_k(y, score, k))
 
     auc = torch.tensor(auc)
     ap = torch.tensor(ap)

--- a/benchmark/utils.py
+++ b/benchmark/utils.py
@@ -70,7 +70,7 @@ def init_model(args):
                      lr=choice(lr),
                      epoch=epoch,
                      gpu=gpu,
-                     alpha=choice(alpha),
+                     wight=choice(alpha),
                      batch_size=batch_size,
                      num_neigh=num_neigh)
     elif model_name == 'dominant':
@@ -80,7 +80,7 @@ def init_model(args):
                         lr=choice(lr),
                         epoch=epoch,
                         gpu=gpu,
-                        alpha=choice(alpha),
+                        wight=choice(alpha),
                         batch_size=batch_size,
                         num_neigh=num_neigh)
     elif model_name == 'done':
@@ -100,7 +100,7 @@ def init_model(args):
                     lr=choice(lr),
                     epoch=epoch,
                     gpu=gpu,
-                    alpha=choice(alpha),
+                    wight=choice(alpha),
                     batch_size=batch_size,
                     num_neigh=num_neigh)
     elif model_name == 'gcnae':

--- a/benchmark/utils.py
+++ b/benchmark/utils.py
@@ -66,7 +66,7 @@ def init_model(args):
                      lr=choice(lr),
                      epoch=epoch,
                      gpu=gpu,
-                     wight=choice(alpha),
+                     weight=choice(alpha),
                      batch_size=batch_size,
                      num_neigh=num_neigh)
     elif model_name == 'dominant':
@@ -76,7 +76,7 @@ def init_model(args):
                         lr=choice(lr),
                         epoch=epoch,
                         gpu=gpu,
-                        wight=choice(alpha),
+                        weight=choice(alpha),
                         batch_size=batch_size,
                         num_neigh=num_neigh)
     elif model_name == 'done':
@@ -96,7 +96,7 @@ def init_model(args):
                     lr=choice(lr),
                     epoch=epoch,
                     gpu=gpu,
-                    wight=choice(alpha),
+                    weight=choice(alpha),
                     batch_size=batch_size,
                     num_neigh=num_neigh)
     elif model_name == 'gcnae':

--- a/benchmark/utils.py
+++ b/benchmark/utils.py
@@ -34,11 +34,7 @@ def init_model(args):
     else:
         hid_dim = [32, 64, 128, 256]
 
-    if args.dataset[:3] == 'inj' or args.dataset[:3] == 'gen':
-        # auto balancing on injected dataset
-        alpha = [None]
-    else:
-        alpha = [0.8, 0.5, 0.2]
+    alpha = [0.8, 0.5, 0.2]
 
     if model_name == "adone":
         return AdONE(hid_dim=choice(hid_dim),


### PR DESCRIPTION
Fixed issue #85
- [x] The argument of `torch.mean()`, `toch.std()`, and `torch.max()` should be a tensor float type instead of list.
- [x] `eval_recall_at_k()` return tensor float type value, it must convert to list type float value to append into the `rec` list.
\
\
Fixed issue #83
- [x] Remove heuristic selection of `weight`.
- [x] Update the parameter name for detectors (`DOMINANT`, `GAAN`, and `CONAD`) from `alpha` to `weight`.

Issues #83, #85, and the above solutions are tested on **torch 2.0.1+cu117**.